### PR TITLE
PC Card deprecation notice

### DIFF
--- a/fcp-0010.md
+++ b/fcp-0010.md
@@ -1,0 +1,44 @@
+---
+authors: Warner Losh <imp@bsdimp.com>
+state: draft
+---
+
+# FCP 10: PC Card Deprecation Notice
+
+PC Card has not been relevant in years. It's inclusion in the tree is holding us back.
+
+## Problem Statement
+
+PC Card used to be very relevant. However, the only reason we have a
+number of really old network drivers is due to PC Card. If we were to
+remove it, many of them could be deleted. PC Card is a 16-bit only
+standard. Most relevant hardware that FreeBSD runs on has CardBus
+slots, and the 32-bit PCI cards are still well supported.
+
+There's little enough traffic on CardBus cards in the mobile mailing
+list, and none for PC Cards in many years.
+
+## Proposed Solution
+
+We will remove PC Card from the tree. We will also remove drivers that are
+only in the tree for PC Card support, and all the PC Card attachments.
+
+The unforunately named /etc/pccard_ether, run when a network card is
+inserted into the system, will remain a quaint anachronism.
+
+PC Card is supported on i386, amd64 and Power PC.
+
+The following drivers will have their PC Card attachemnt removed:
+	an, ata, ed, fdc, puc, sio, uart, wi
+
+The following drivers will be deleted:
+	cmx, ep, ex, fe, ncv, nsp, pccard, sn, stg, xe, bt3c
+
+## Proposed Timeline
+
+August 2018 Add deprecation notices to the pccard bridge code before the 12.0 release
+August 2018 Post to mobile@ and arch@ plans to remove things, point them at this draft
+November 2018 Remove PC Card from -current. Remove PC Card attachments. Remove all drivers
+	that are PC Card only.
+
+## Final Disposition


### PR DESCRIPTION
Sample deprecation notice: PC Card's time has gone. We're planning on removing it.