### PR TITLE
Allocate FCP 101.

### DIFF
--- a/index.md
+++ b/index.md
@@ -4,3 +4,4 @@ FCP                       | State     | Owners                | Title
 --------------------------|-----------|-----------------------|------
 [FCP 0](./fcp-0000.md)    | accepted  | allanjude, gnn, benno | FreeBSD Community Proposal Process and Authoring Guide
 [FCP 100](./fcp-0100.md)  | draft     | imp                   | Creating armv7 MACHINE_ARCH
+[FCP 101](./fcp-0101.md)  | draft     | brooks                | Deprecation and removal of 10/100 Ethernet drivers


### PR DESCRIPTION
Allocate FCP 101 for a proposal to remove most 10/100 Ethernet devices.