### PR TITLE
Refine the language about editing an FCP

### DIFF
--- a/fcp-0000.md
+++ b/fcp-0000.md
@@ -146,8 +146,8 @@ SHOULD be updated to the `vote` state.
 At this time the FreeBSD Core Team will vote on the subject of the FCP. The
 result of vote moves the FCP into the `accepted` or `rejected` state.
 
-FCPs in the `accepted` state can be
-updated and corrected. See the "Touching up" section for more information.
+FCPs in the `accepted` state can be updated and corrected.
+See the "Changes after acceptance" section for more information.
 
 The authors may withdraw an FCP at any time. If an FCP is not
 viable or if an FCP is to be ignored, it can be moved into the `withdrawn`
@@ -281,8 +281,5 @@ withdrawal.
 ### Changes after acceptance
 
 FCPs may need revision after they have been moved into the `accepted`
-state.  If the changes are minor, the author SHOULD update the FCP. If
+state.  In such cases, the author SHOULD update the FCP to reflect the final conclusions. If
 the changes are major, the FCP SHOULD be withdrawn and restarted.
-
-Examples of minor changes include spelling corrections or wording changes that do not change
-the meaning of the document.


### PR DESCRIPTION
There was a hanging forward reference which I removed, and I softened the language about when to start a new FCP vs edit the old one.