### PR TITLE
FCP-0101: Remove (most) 10/100 Ethernet drivers

### DIFF
--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -1,0 +1,65 @@
+---
+authors: Brooks Davis <brooks@freebsd.org>
+state: feedback
+---
+
+# FCP 101: Deprecation and removal of 10/100 Ethernet drivers
+
+Deprecate most 10 and 10/100Mbps Ethernet drivers and remove them before
+FreeBSD 13.
+
+## Problem Statement
+
+Each network driver creates drag for the project as we attempt to
+improve the network stack or provide new features such as expanded
+32-bit compatibility.  10 and 100 megabit Ethernet drives are largely
+irrelevant today and we have a significant number of them in the
+tree.
+
+For at least a decade, most systems (including small embedded
+systems) have shipped with gigabit Ethernet devices and virtual
+machines commonly emulate popular gigabit devices.  We wish to
+retain support for popular physical and virtual devices while
+removing support for uncommon ones.  With a few exceptions these
+drivers are unlikely to be used by our user base by the time FreeBSD
+12 is obsolete.
+
+## Proposed Solution
+
+We propose to deprecate devices which are not sufficiently popular.  This
+will entail:
+ - (August 2018) Send this list to freebsd-net and freebsd-stable.
+ - (Before FreeBSD 12.0-RELEASE - September 2018) Update the manpages and
+   attach routines for each device to be removed and merge those changes
+   to FreeBSD 12.
+ - (One month after FreeBSD 12.0-RELEASE - December 2018) Remind
+   freebsd-net and freebsd-stable users of pending deletion.
+ - (Two months after FreeBSD 12.0-RELEASE - January 2019) Delete deprecated
+   devices.
+
+Through out this process, solicit feedback on additions to the exception
+list and update this document as required.  For a device to be placed on
+the exception list, it must be popular in applications where it will
+continue to be used beyond the support lifetime of FreeBSD 12 (late
+2023).
+
+### Exceptions to removal
+
+Device | Reason
+-------|-------------------------------------------------
+ffec   | Onboard Ethernet for Vybrid arm7 boards
+fxp    | Popular device long recommended by the project.
+dc     | Popular device for CardBus card.
+le     | Emulated by QEMU, alternatives don't yet work for mips64.
+sis    | Soekris Engineering net45xx, net48xx, lan1621, and lan1641.
+
+Note: USB devices have been excluded from consideration in this round.
+
+### Device to be removed
+
+ae, bfe, bm, cs, dme, ed, ep, ex, fe, hme, nfe, pcn, rl, sf, smc, sn,
+ste, tl, tx, txp, vr, vx, wb, xe, xl
+
+## Final Disposition
+
+TBD

--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -52,13 +52,14 @@ fxp    | Popular device long recommended by the project.
 dc     | Popular device for CardBus card.
 le     | Emulated by QEMU, alternatives don't yet work for mips64.
 sis    | Soekris Engineering net45xx, net48xx, lan1621, and lan1641.
+xl     | Popular device for CardBus card.
 
 Note: USB devices have been excluded from consideration in this round.
 
 ### Device to be removed
 
 ae, bfe, bm, cs, dme, ed, ep, ex, fe, hme, nfe, pcn, rl, sf, smc, sn,
-ste, tl, tx, txp, vr, vx, wb, xe, xl
+ste, tl, tx, txp, vr, vx, wb, xe
 
 ## Final Disposition
 

--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -50,6 +50,7 @@ Device | Reason
 ffec   | Onboard Ethernet for Vybrid arm7 boards
 fxp    | Popular device long recommended by the project.
 dc     | Popular device for CardBus card.
+hme    | Built in interface on many supported sparc64 platforms.
 le     | Emulated by QEMU, alternatives don't yet work for mips64.
 sis    | Soekris Engineering net45xx, net48xx, lan1621, and lan1641.
 xl     | Popular device for CardBus card.
@@ -58,7 +59,7 @@ Note: USB devices have been excluded from consideration in this round.
 
 ### Device to be removed
 
-ae, bfe, bm, cs, dme, ed, ep, ex, fe, hme, nfe, pcn, rl, sf, smc, sn,
+ae, bfe, bm, cs, dme, ed, ep, ex, fe, nfe, pcn, rl, sf, smc, sn,
 ste, tl, tx, txp, vr, vx, wb, xe
 
 ## Final Disposition


### PR DESCRIPTION
This FCP begins the process of cleaning up obsolete Ethernet drivers.  10/100Mbps, non-USB drivers present a pretty clear line in the sand (vs. e.g. gigabit ethernet devices that failed in the market.)

After an initial review during this pull request, it will be ready for broader feedback.