### PR TITLE
Fcp 0101: Improve justification and remove errant driver

### DIFF
--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -59,7 +59,7 @@ Note: USB devices have been excluded from consideration in this round.
 
 ### Device to be removed
 
-ae, bfe, bm, cs, dme, ed, ep, ex, fe, nfe, pcn, rl, sf, smc, sn,
+ae, bfe, bm, cs, dme, ed, ep, ex, fe, pcn, rl, sf, smc, sn,
 ste, tl, tx, txp, vr, vx, wb, xe
 
 ## Final Disposition

--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -12,9 +12,13 @@ FreeBSD 13.
 
 Each network driver creates drag for the project as we attempt to
 improve the network stack or provide new features such as expanded
-32-bit compatibility.  10 and 100 megabit Ethernet drives are largely
-irrelevant today and we have a significant number of them in the
-tree.
+32-bit compatibility.  For example, the author has edited every single
+NIC driver more than once in the past year to update management (`ioctl`)
+interfaces.  We could improve this situation by converting drivers to
+iflib, but each additional driver takes work.
+
+10 and 100 megabit Ethernet drivers are largely irrelevant today
+and we have a significant number of them in the tree.
 
 For at least a decade, most systems (including small embedded
 systems) have shipped with gigabit Ethernet devices and virtual
@@ -22,7 +26,7 @@ machines commonly emulate popular gigabit devices.  We wish to
 retain support for popular physical and virtual devices while
 removing support for uncommon ones.  With a few exceptions these
 drivers are unlikely to be used by our user base by the time FreeBSD
-12 is obsolete.
+12 is obsolete (approximately 2024).
 
 ## Proposed Solution
 

--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -18,7 +18,9 @@ interfaces.  We could improve this situation by converting drivers to
 iflib, but each additional driver takes work.
 
 10 and 100 megabit Ethernet drivers are largely irrelevant today
-and we have a significant number of them in the tree.
+and we have a significant number of them in the tree.  The ones that
+are no longer used and/or are not known to be working need to be
+removed due to the significant ongoing 'tax' on new development.
 
 For at least a decade, most systems (including small embedded
 systems) have shipped with gigabit Ethernet devices and virtual


### PR DESCRIPTION
Expand the justification for limiting the number of NIC drivers.

Remove nfe from the document as it was added in error.

Partially superceeds #20.  Partially resolves #19.