### PR TITLE
Add vr to the exclustion list.

### DIFF
--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -59,6 +59,7 @@ dc     | Popular device for CardBus card.
 hme    | Built in interface on many supported sparc64 platforms.
 le     | Emulated by QEMU, alternatives don't yet work for mips64.
 sis    | Soekris Engineering net45xx, net48xx, lan1621, and lan1641.
+vr     | Soekris Engineering net5501, some Asus motherboards.
 xl     | Popular device for CardBus card.
 
 Note: USB devices have been excluded from consideration in this round.
@@ -66,7 +67,7 @@ Note: USB devices have been excluded from consideration in this round.
 ### Device to be removed
 
 ae, bfe, bm, cs, dme, ed, ep, ex, fe, pcn, rl, sf, smc, sn,
-ste, tl, tx, txp, vr, vx, wb, xe
+ste, tl, tx, txp, vx, wb, xe
 
 ## Final Disposition
 


### PR DESCRIPTION
It's onboard on the Soekris Engineering net5501.

Requested by @cschuber.