### PR TITLE
Add vte to the STAY list.

### DIFF
--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -68,6 +68,7 @@ le     | Emulated by QEMU, alternatives don't yet work for mips64.
 rl     | Popular in the P-III era and reported to ship in embedded systems.
 sis    | Soekris Engineering net45xx, net48xx, lan1621, and lan1641.
 vr     | Soekris Engineering net5501, some Asus motherboards.
+vte    | Still shipping in embedded systems, GbE capable (not in tree).
 xl     | Popular device for CardBus card.
 
 Note: USB devices have been excluded from consideration in this round.


### PR DESCRIPTION
From @bsdimp:
> It appears in a number of embedded products, including the Vortex86 line
> which was produced by SiS years ago (i686 timeframe), but has been
> clocked up past 1GHz and the latest version is still in production and
> beefy enough to run FreeBSD. Since it's an embedded SoC, it's hard to
> slot in a different NIC on these boxes.

Note: FreeBSD's driver doesn't support GbE at this time.