### PR TITLE
Add smc to the SAVE list.

### DIFF
--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -67,6 +67,7 @@ hme    | Built in interface on many supported sparc64 platforms.
 le     | Emulated by QEMU, alternatives don't yet work for mips64.
 rl     | Popular in the P-III era and reported to ship in embedded systems.
 sis    | Soekris Engineering net45xx, net48xx, lan1621, and lan1641.
+smc    | ARM Foundation Model simulator.
 ste    | Deployed 2-/4-port cards are hard to replace.
 vr     | Soekris Engineering net5501, some Asus motherboards.
 vte    | Still shipping in embedded systems, GbE capable (not in tree).
@@ -76,8 +77,7 @@ Note: USB devices have been excluded from consideration in this round.
 
 ### Device to be removed
 
-ae, bfe, bm, cs, de, dme, ed, ep, ex, fe, pcn, sf, smc, sn,
-tl, tx, txp, vx, wb, xe
+ae, bfe, bm, cs, de, dme, ed, ep, ex, fe, pcn, sf, sn, tl, tx, txp, vx, wb, xe
 
 ## Final Disposition
 


### PR DESCRIPTION
It is used by simulators including the ARM Foundation Model.