### PR TITLE
Add dme(4) to the keep list.

### DIFF
--- a/fcp-0101.md
+++ b/fcp-0101.md
@@ -63,6 +63,7 @@ Device | Reason
 -------|-------------------------------------------------
 bfe    | Cleared the popularity bar during feedback.
 dc     | Popular device for CardBus card.
+dme    | Built in interface on Creator CI20 and Ingenic JZ47XX.
 fxp    | Popular device long recommended by the project.
 hme    | Built in interface on many supported sparc64 platforms.
 le     | Emulated by QEMU, alternatives don't yet work for mips64.
@@ -78,7 +79,7 @@ Note: USB devices have been excluded from consideration in this round.
 
 ### Device to be removed
 
-ae, bm, cs, de, dme, ed, ep, ex, fe, pcn, sf, sn, tl, tx, txp, vx, wb, xe
+ae, bm, cs, de, ed, ep, ex, fe, pcn, sf, sn, tl, tx, txp, vx, wb, xe
 
 ## Summary of discussions and supporting data
 


### PR DESCRIPTION
It is the built-in NIC on some non-expandable mips platforms.